### PR TITLE
BP-6029 | Update changesets to include associated changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ t.amount                         # 100
 t.location.latitude              # 12.345, instead of 54.321
 ```
 
+When calling `changeset` on a `version` you can include changes to associations by specifying the following options 
+
+- To restore Has-Many-Through associations, use option `has_many_through: true`
+
+For example:
+
+```ruby
+item.versions.last.changeset(has_many_through: true)
+```
+
 # Limitations
 
 1. Only reifies the first level of associations. If you want to include nested associations simply add `:through` relationships to your model.

--- a/lib/paper_trail-association_tracking.rb
+++ b/lib/paper_trail-association_tracking.rb
@@ -50,6 +50,7 @@ module PaperTrail
 
   module VersionConcern
     include ::PaperTrailAssociationTracking::VersionConcern
+    prepend ::PaperTrailAssociationTracking::VersionConcern::ClassMethods
   end
 end
 


### PR DESCRIPTION
## Jira Ticket

- Fixes BP-6029

## Description

Adds `has_many :through` association changes to `changeset` so that changes can be reflected in the changelog for user_group memberships.

## Dependencies And Related Issues/PRs

N/A

## Deployment Tasks

N/A

## Checklist

- [x] I have added the relevant GitHub labels
- [ ] I have written and run tests
- [x] I have verified my code passes linting (Rubocop, Rails Best Practices, etc.)

## How did you test this?

Mostly manual testing in the Authenticator user edit screens.

## Other Notes

There really aren't any tests in the gem that could be updated.